### PR TITLE
Upgrade BigDecimal use to quash warnings in Ruby 2.5+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.4
-  - 2.4.1
-before_install: gem install bundler -v 1.15.1
+  - 2.6.3
+  - 2.5.5
+before_install: gem install bundler -v 1.17.3

--- a/lib/weetbix/types.rb
+++ b/lib/weetbix/types.rb
@@ -51,7 +51,7 @@ module Weetbix
     serialize BigDecimal,
               to: :string,
               dump: ->(num) { num.to_s("F") },
-              load: BigDecimal
+              load: Kernel.method(:BigDecimal)
     serialize Time,
               to: :string,
               dump: :xmlschema.to_proc,

--- a/lib/weetbix/types.rb
+++ b/lib/weetbix/types.rb
@@ -51,7 +51,7 @@ module Weetbix
     serialize BigDecimal,
               to: :string,
               dump: ->(num) { num.to_s("F") },
-              load: BigDecimal.method(:new)
+              load: BigDecimal
     serialize Time,
               to: :string,
               dump: :xmlschema.to_proc,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,7 +58,7 @@ end
 
 def sample_bar
   foo = Types::Foo.new(
-    amount: BigDecimal.new("5"),
+    amount: BigDecimal("5"),
     timestamp: Time.utc(2009),
   )
   Types::Bar.new(


### PR DESCRIPTION
What is says on the tin. There's all sorts of dependency bollocks going on because age, too but I think just this change will help block the many hundreds of exploding the Zuul test logs.